### PR TITLE
Fixed overflow hidden issue on preview containers.

### DIFF
--- a/components/_preview.twig
+++ b/components/_preview.twig
@@ -19,8 +19,8 @@
       }
       .preview-inner-container {
         margin-bottom: 70px;
-        clear: both;
-        overflow: hidden;
+        display: inline-block;
+        width: 100%;
       }
     </style>
 </head>


### PR DESCRIPTION
There was an overflow issue for the preview-inner-container class (only used within the style guide to add spacing to the elements on preview pages). This should fix that.