### PR TITLE
Fix table row colors for tables with thead and tbody tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this style guide are documented here.
 
 NOTE: Refer to upcoming changes in our README.md under "Roadmap"
 
+## [Unreleased]
+
+### Fixed
+
+* Table row color for tables that both have a `thead` and `tbody` element.
+
 ## [3.0.0-beta6]
 
 ### Added

--- a/components/21-atoms/table/_table.scss
+++ b/components/21-atoms/table/_table.scss
@@ -50,6 +50,20 @@ div.responsive-table {
       @include theme('background-color', 'color-secondary', 'table-first-row-color');
     }
 
+    thead ~ tbody {
+      tr:nth-child(2n+1) th,
+      tr:nth-child(2n+1) td {
+        [class*="cs--"] & {
+          background-color: unset;
+        }
+      }
+
+      tr:nth-child(2n) th,
+      tr:nth-child(2n) td {
+        @include theme('background-color', 'color-primary--lighten-5', 'table-row-color');
+      }
+    }
+
     th,
     td {
       @include theme('color', 'color-tertiary', 'table-content-color');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed table row colors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`nth-child` wasn't scoping correctly for tables with the following markup

```html
<table>
	<thead>
		<tr>...<tr>
	</thead>
	<tbody>
		<tr>...<tr>
		<tr>...<tr>
		<tr>...<tr>
	</tbody>
</table>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
- [ ] I have ran gulp axe on the compiled files and found no errors.
