### PR TITLE
Updated image gallery width to 10 columns in detail layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: Refer to upcoming changes in our README.md under "Roadmap"
 
 * Added class `form-steps-list` to make Form Steps extendable.
 * Make it possible to override the icon of `button-alert`.
+* Changed width of image gallery to 10 columns in the Detail layout.
 
 ### Fixed
 

--- a/components/61-layouts/detail-layout/_detail-layout.scss
+++ b/components/61-layouts/detail-layout/_detail-layout.scss
@@ -38,7 +38,6 @@
   }
 
   > .quote-wrapper,
-  > .image-gallery--wrapper.multiple,
   > .help-block,
   > .search-block {
     @include desktop {
@@ -51,6 +50,7 @@
   > .cta-block,
   > .contact-block,
   > .contact-details,
+  > .image-gallery--wrapper.multiple,
   > .contact-box {
     @include desktop {
       @include set-layout('width-10', 'offset-1');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As described in the design, the image gallery should be 10 columns wide

![Screenshot 2019-05-17 at 07 47 55](https://user-images.githubusercontent.com/4415097/57905810-1b3e7f00-7878-11e9-8a8b-e51eeb3b0911.png)
_(src: https://zpl.io/2vNwev5)_

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
