### PR TITLE
DTGB-726: Fixed correct wrapping of breadcrumbs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ NOTE: Refer to upcoming changes in our README.md under "Roadmap"
 
 * Font-size of avatar is now 26px instead of 24px.
 * Cross-browser behavior for icon buttons.
+* Fixed correct wrapping of breadcrumbs.
 
 ### Removed
 

--- a/components/31-molecules/breadcrumbs/_breadcrumbs.scss
+++ b/components/31-molecules/breadcrumbs/_breadcrumbs.scss
@@ -9,7 +9,7 @@
     li {
       @include icon('chevron-right', 'after');
 
-      display: inline-block;
+      display: inline;
       margin-right: .4rem;
 
       &::after {

--- a/components/31-molecules/breadcrumbs/breadcrumbs.config.js
+++ b/components/31-molecules/breadcrumbs/breadcrumbs.config.js
@@ -8,7 +8,7 @@ module.exports = {
       '<a href="#">Home</a>',
       '<a href="#">Overview</a>',
       '<span>Overview</span>',
-      '<span>Overview</span>',
+      '<span>Page with a long title to see how the breadcrumb gets wrapped</span>',
       '<span>Page title</span>'
     ]
   }


### PR DESCRIPTION
When a breadcrumb contains long page titles then they will wrapped within the li on a separate line (inline-block).
Better to display them inline.

## Description

Changed the breadcrumb li display from "inline-block" to "inline".

## Motivation and Context

Less waste of screen estate.

## How Has This Been Tested?

User testing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
