### PR TITLE
Change paddings for box-top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this style guide are documented here.
 
 NOTE: Refer to upcoming changes in our README.md under "Roadmap"
 
+## [Unreleased]
+
+### Updated
+
+* Changed paddings for box with spot image at the top.
+
+### Fixed
+
+* Make show-more class for grid more specific, since "show-more" conflicts with
+  other libraries.
+    > **:warning: BREAKING CHANGE:** Rename "show-more" to "grid__show-more"
+
 ## [3.0.0-beta10]
 
 ### Added

--- a/components/11-base/boxes/_boxes.scss
+++ b/components/11-base/boxes/_boxes.scss
@@ -81,7 +81,7 @@
   .inner-box {
 
     @include tablet {
-      padding-top: 5rem;
+      padding-right: 9rem;
 
       &::before {
         top: -3.5rem;

--- a/components/41-organisms/collection/_collection.scss
+++ b/components/41-organisms/collection/_collection.scss
@@ -17,7 +17,7 @@ ul.grid-5 {
   }
 }
 
-.show-more {
+.grid__show-more {
   margin: 1.2rem 0;
   font-size: .9rem;
   text-align: center;

--- a/components/41-organisms/collection/collection--with-show-more.twig
+++ b/components/41-organisms/collection/collection--with-show-more.twig
@@ -1,6 +1,6 @@
 {% include '@collection--grid-4' %}
 
-<div class="show-more">
+<div class="grid__show-more">
   {% include '@link' with {
     'link': null,
     'text': 'Show all news articles',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added padding to the right of the box-top on tablet resolutions and higher. 
_(aaaaand I slipped in another bugfix as well)_

### Before
![Screenshot 2019-07-31 at 16 00 08](https://user-images.githubusercontent.com/4415097/62218306-79c1c680-b3ac-11e9-929e-1a19a41f7877.png)

### After
![Screenshot 2019-07-31 at 16 00 44](https://user-images.githubusercontent.com/4415097/62218313-7d554d80-b3ac-11e9-91ae-8618d53673fd.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
