### PR TITLE
STIJ-265: Added alignment fix for programme component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ NOTE: Refer to upcoming changes in our README.md under "Roadmap"
 * Blue background when focusing on select element in IE11/Edge.
 * DTGB-728: Fixed line height for input date on mobile safari.
 * DTGB-731: Fixed underline color of links in the cs--orange theme.
-* Alignment of programme component titel and teasers.
+* Alignment of programme component title and teasers.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ NOTE: Refer to upcoming changes in our README.md under "Roadmap"
 * Blue background when focusing on select element in IE11/Edge.
 * DTGB-728: Fixed line height for input date on mobile safari.
 * DTGB-731: Fixed underline color of links in the cs--orange theme.
+* Alignment of programme component titel and teasers.
 
 ### Removed
 

--- a/components/41-organisms/programme/_programme.scss
+++ b/components/41-organisms/programme/_programme.scss
@@ -1,7 +1,6 @@
 .programme {
   > .inner-box {
-    padding-top: 4.8rem;
-    padding-bottom: 4rem;
+    padding: 4.8rem 2rem 4rem;
 
     &::before {
       @include spot-image('calendar');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Changing padding on the boxes component broke the alignment of the title and teasers of the programme component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
BEFORE:
<img width="1680" alt="Screenshot 2019-09-12 at 14 44 47" src="https://user-images.githubusercontent.com/30627591/64785571-fbd90980-d56c-11e9-8a3b-3a1421d437d5.png">

AFTER:
<img width="1680" alt="Screenshot 2019-09-12 at 14 44 55" src="https://user-images.githubusercontent.com/30627591/64785581-03001780-d56d-11e9-8440-29d4c5ff2bf5.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
