### PR TITLE
STIJ-278: Removed obsolete whitespace from form columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ update your template accordingly.
 * Filter layout sidebar overflow.
 * Keyboard bug on checkboxes with filter.
 * Fixed width of images in wide teasers.
+* Fixed form-columns whitespace.
 
 ## [3.0.0-beta14]
 

--- a/components/31-molecules/form-item/_form-item.scss
+++ b/components/31-molecules/form-item/_form-item.scss
@@ -19,7 +19,7 @@
 
   &:not(.stacked) {
     .form-columns {
-      margin-bottom: 1.2rem;
+      margin-bottom: 0;
 
       @include desktop {
         display: flex;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed obsolete whitespace from form-columns class. This caused elements to have too much whitespace.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2019-11-13 at 10 41 59](https://user-images.githubusercontent.com/30627591/68751671-46751180-0602-11ea-9143-02e04b5d3cc3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
