### PR TITLE
STIJ-268: Merged contact-block in to a generic CTA-block component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ NOTE: Refer to upcoming changes in our README.md under "Roadmap"
   in order to match the documentation.  
   The '.mijn-gent-block' class is still functional but marked as deprecated.
   Please use '.authentication' from now on.
+* **Breaking** 'CTA-block' now uses the generic highlight component.
+  The old template and classes will be removed in the next major version.
+  
+### Removed
+
+* **Deprecated** 'contact-block' has been marked as deprecated in favour of the generic 'CTA-block'.
+  Templates and classes will be removed in the next major version.
 
 ## [3.0.0-beta17]
 

--- a/components/31-molecules/contact-block/contact-block.config.js
+++ b/components/31-molecules/contact-block/contact-block.config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  status: 'alpha',
+  status: 'deprecated',
   context: {
     title: 'Contact us',
     description: 'Nulla nec eros lorem. Morbi at augue eu purus congue auctor. Sed id volutpat odio. Nunc congue diam vel diam venenatis, ut consequat urna dapibus. Vivamus at lobortis odio. Sed felis mauris, mattis eget purus at, pharetra ullamcorper risus.',

--- a/components/31-molecules/cta-block/_cta-block.scss
+++ b/components/31-molecules/cta-block/_cta-block.scss
@@ -1,19 +1,21 @@
 .cta-block {
 
+  /// @deprecated
   &.link .inner-box::before {
     @include spot-image('link-light', 7rem);
   }
 
+  /// @deprecated
   &.download .inner-box::before {
     @include spot-image('download-light', 7rem);
   }
 
-  .inner-box {
-
-    min-height: 11rem;
+  .inner-box, /// @deprecated
+  .highlight__inner {
+    min-height: 11rem; /// @deprecated
 
     li {
-      width: 100%;
+      width: 100%; /// @deprecated
       margin-top: .8rem;
 
       &:first-of-type a {
@@ -22,11 +24,11 @@
         @include button-icon;
       }
 
-      &:last-of-type {
+      &:not(:last-of-type) {
         @include theme('border-color', 'color-primary--lighten-4', 'more-info-block-border-color');
 
-        padding-top: .8rem;
-        border-top: 2px solid;
+        padding-bottom: .8rem;
+        border-bottom: 2px solid;
       }
     }
   }
@@ -44,7 +46,8 @@
       margin-right: 1rem;
       margin-left: 1rem;
 
-      .inner-box {
+      .inner-box, /// @deprecated
+      .highlight__inner {
         height: 100%;
 
         @include tablet {

--- a/components/31-molecules/cta-block/cta-block.config.js
+++ b/components/31-molecules/cta-block/cta-block.config.js
@@ -14,20 +14,7 @@ module.exports = {
         description: false,
         links: [
           {
-            text: 'When the weather is hot',
-            url: '#'
-          }
-        ]
-      }
-    },
-    {
-      name: 'default with long title',
-      context: {
-        description: false,
-        title: 'Dit is een titel. Liquorice chocolate ice cream cheesecake jelly beans marzipan chocolate.',
-        links: [
-          {
-            text: 'When the weather is hot',
+            text: 'An internal link',
             url: '#'
           }
         ]
@@ -45,33 +32,52 @@ module.exports = {
       }
     },
     {
-      name: 'with secondary action (link)',
+      name: 'with secondary action',
       context: {
         links: [
           {
-            text: 'In the summertime',
+            text: 'Internal link',
             url: '#'
           },
           {
-            text: 'When the weather is hot',
+            text: 'Internal link',
             url: '#'
           }
         ]
       }
     },
     {
-      name: 'with secondary action (download)',
+      name: 'phone',
       context: {
+        type: 'phone',
+        title: 'Contact us',
+        description: 'Nulla nec eros lorem. Morbi at augue eu purus congue auctor. Sed id volutpat odio. Nunc congue diam vel diam venenatis, ut consequat urna dapibus. Vivamus at lobortis odio. Sed felis mauris, mattis eget purus at, pharetra ullamcorper risus.',
         links: [
           {
-            text: 'In the summertime',
-            url: '#'
+            text: '09 123 123',
+            url: 'tel:#'
           },
           {
-            text: 'When the weather is hot',
-            url: '#',
-            document: 'document',
-            size: '102kb'
+            text: 'Check all contact details',
+            url: '#'
+          }
+        ]
+      }
+    },
+    {
+      name: 'e-mail',
+      context: {
+        type: 'mail',
+        title: 'Contact us',
+        description: 'Nulla nec eros lorem. Morbi at augue eu purus congue auctor. Sed id volutpat odio. Nunc congue diam vel diam venenatis, ut consequat urna dapibus. Vivamus at lobortis odio. Sed felis mauris, mattis eget purus at, pharetra ullamcorper risus.',
+        links: [
+          {
+            text: 'info@stad.gent',
+            url: 'mailto:#'
+          },
+          {
+            text: 'Check all contact details',
+            url: '#'
           }
         ]
       }
@@ -82,48 +88,14 @@ module.exports = {
         type: 'download',
         links: [
           {
-            text: 'When the weather is hot',
-            url: '#',
-            document: 'document',
-            size: '102kb'
-          }
-        ]
-      }
-    },
-    {
-      name: 'download with secondary action (link)',
-      context: {
-        type: 'download',
-        links: [
-          {
-            text: 'In the summertime',
+            text: 'A download link',
             url: '#',
             document: 'document',
             size: '102kb'
           },
           {
-            text: 'When the weather is hot',
+            text: 'An internal link',
             url: '#'
-          }
-        ]
-      }
-    },
-    {
-      name: 'download with secondary action (download)',
-      context: {
-        type: 'download',
-        links: [
-          {
-            text: 'In the summertime',
-            url: '#',
-            document: 'document',
-            size: '102kb'
-          },
-          {
-            text: 'When the weather is hot',
-            url: '#',
-            document: 'document',
-            size: '102kb'
           }
         ]
       }
@@ -137,13 +109,13 @@ module.exports = {
             type: 'download',
             links: [
               {
-                text: 'In the summertime',
+                text: 'A download link',
                 url: '#',
                 document: 'document',
                 size: '102kb'
               },
               {
-                text: 'When the weather is hot',
+                text: 'Another download link',
                 url: '#',
                 document: 'document',
                 size: '102kb'
@@ -153,11 +125,11 @@ module.exports = {
           {
             links: [
               {
-                text: 'In the summertime',
+                text: 'An internal link',
                 url: '#'
               },
               {
-                text: 'When the weather is hot',
+                text: 'A download link',
                 url: '#',
                 document: 'document',
                 size: '102kb'
@@ -165,7 +137,6 @@ module.exports = {
             ]
           }
         ]
-
       }
     }
   ]

--- a/components/31-molecules/cta-block/cta-block.twig
+++ b/components/31-molecules/cta-block/cta-block.twig
@@ -1,50 +1,50 @@
-<div class="cta-block box-{{ top ? 'top' : 'left' }} {{ type }}">
-  <div class="inner-box">
-    <div>
-      {% if title %}
-        {% include '@heading' with {
-        'type': 'h2',
-        'heading_text': title
-        } %}
-      {% endif %}
+{% set content %}
+  {% if title %}
+    {% include '@heading' with {
+      'type': 'h2',
+      'heading_text': title
+    } %}
+  {% endif %}
 
-      {% if description %}
-        {% include '@paragraph' with {
-        'text': description
-        } %}
-      {% endif %}
+  {% if description %}
+    {% include '@paragraph' with {
+      'text': description
+    } %}
+  {% endif %}
 
-      {% if links|length > 1 %}
-      <ul class="links">
-      {% endif %}
-        {% for link in links %}
-          {% set options = {
-            link: link.url,
-            text: link.text,
-            modifier: loop.first ? 'button button-primary' : 'standalone-link'
-          } %}
+  <{{ links|length > 1 ? 'ul' : 'div'}} class="links">
+  {% for link in links %}
+    {% set options = {
+      link: link.url,
+      text: link.text,
+      modifier: loop.first ? 'button button-primary' : 'standalone-link'
+    } %}
 
-          {% if link.size|length %}
-            {% set options = options|merge({
-              file: {
-                size: link.size,
-                type: 'pdf'
-              }
-            }) %}
-          {% endif %}
+    {% if link.size|length %}
+      {% set options = options|merge({
+        file: {
+          size: link.size,
+          type: 'pdf'
+        }
+      }) %}
+    {% endif %}
 
-          {% if links|length > 1 %}
-          <li>
-          {% endif %}
-            {% include '@file-download' with options %}
-          {% if links|length > 1 %}
-          </li>
-          {% endif %}
-        {% endfor %}
+    {% if links|length > 1 %}
+      <li>
+    {% endif %}
+    {% include '@file-download' with options %}
+    {% if links|length > 1 %}
+      </li>
+    {% endif %}
+  {% endfor %}
+  <{{ links|length > 1 ? '/ul' : '/div'}} class="links">
+{% endset %}
 
-      {% if links|length > 1 %}
-      </ul>
-      {% endif %}
-    </div>
-  </div>
-</div>
+{% include "@highlight" with {
+  content: content,
+  modifier: top ? 'top' : 'left',
+  classes: [
+    'cta-block',
+    type
+  ]
+} %}

--- a/components/31-molecules/highlight/_highlight.scss
+++ b/components/31-molecules/highlight/_highlight.scss
@@ -46,6 +46,13 @@
 .box-top { /// @deprecated
   padding-top: 3.5rem;
 
+  $icons: book camera download form letter link loupe mail newsletter phone quote upload whistle;
+  @each $icon in $icons {
+    &.#{$icon} .highlight__inner::before {
+      @include spot-image($icon + '-light', 7rem);
+    }
+  }
+
   .highlight__inner,
   .inner-box { /// @deprecated
     @include tablet-and-below {

--- a/fractal.js
+++ b/fractal.js
@@ -31,7 +31,7 @@ fractal.components.set('statuses', {
   deprecated: {
     label: 'deprecated',
     description: 'Deprecated.',
-    color: '#dd5e01'
+    color: 'rgb(182, 11, 41)'
   },
   alpha: {
     label: 'alpha',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Marked contact-block as deprecated
* Refactored CTA-block to extend the generic highlight component.
* Updated the highlight component to accept spot-icon modifiers.

Old templates and classes will continue to work until the next major release.

## Motivation and Context
Too much duplicate styling.
Both components serve the same function, but lacked flexibility to change the spot-icon.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/31842807/75252862-c4d67780-57dd-11ea-9da9-15c6812d8f56.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
