### PR TITLE
Moved .filter-section styling to outside the .filter parent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this style guide are documented here.
 * Added "about" to read more link value
 * Fixed table bindings. Bind table functions to `'.responsive-table .table-wrapper'`
   instead of `'.responsive-table'` to fix WCAG scrollable content violation.
+* Fixed fieldset styling in filter layout modal. Make sure the `.filter-section`
+  also has class `sidebar`.
 
 ### Updated
 

--- a/components/41-organisms/filter/_filter.scss
+++ b/components/41-organisms/filter/_filter.scss
@@ -1,91 +1,4 @@
 .filter {
-  .filter-section {
-    padding-top: .7rem;
-    visibility: hidden;
-
-    @include desktop {
-      position: static;
-      height: auto;
-      box-shadow: none;
-      overflow: visible;
-      visibility: visible;
-      z-index: auto;
-    }
-
-    &.visible {
-      @include breakpoint(max-width $bp-desktop) {
-        padding: 0;
-        visibility: visible;
-
-        > .modal-inner > .modal-header {
-          display: block;
-        }
-      }
-    }
-
-    > .modal-inner {
-      width: 100%;
-      max-width: initial;
-      min-height: 100%;
-      margin: 0;
-      padding: 0;
-
-      @include desktop {
-        position: relative;
-        top: 0;
-        left: 0;
-        transform: none;
-        z-index: auto;
-        filter: none;
-      }
-
-      > .modal-header {
-        display: none;
-      }
-
-      > .modal-content {
-        @include desktop {
-          padding: 0;
-          overflow: visible;
-        }
-      }
-
-      > .modal-actions {
-        @include desktop {
-          padding-right: 0;
-          padding-left: 0;
-          border: 0;
-        }
-      }
-    }
-
-    > .modal-overlay {
-      display: none;
-    }
-
-    form {
-      // style first level labels as headings
-      > .form-item > label,
-      > fieldset.form-item > legend {
-        @extend %h3;
-      }
-
-      > fieldset {
-        padding: 0;
-        border: 0;
-      }
-    }
-
-    .label-optional {
-      display: none;
-    }
-
-    .filter__submit {
-      margin-top: .8rem;
-      margin-bottom: .8rem;
-    }
-  }
-
   .result-section {
 
     .selected-filters,
@@ -147,5 +60,94 @@
         }
       }
     }
+  }
+}
+
+// On mobile the filter-section is moved to the body root because it is converted to a modal.
+// This means it's no longer a child of .filter.
+.sidebar.filter-section {
+  padding-top: .7rem;
+  visibility: hidden;
+
+  @include desktop {
+    position: static;
+    height: auto;
+    box-shadow: none;
+    overflow: visible;
+    visibility: visible;
+    z-index: auto;
+  }
+
+  &.visible {
+    @include breakpoint(max-width $bp-desktop) {
+      padding: 0;
+      visibility: visible;
+
+      > .modal-inner > .modal-header {
+        display: block;
+      }
+    }
+  }
+
+  > .modal-inner {
+    width: 100%;
+    max-width: initial;
+    min-height: 100%;
+    margin: 0;
+    padding: 0;
+
+    @include desktop {
+      position: relative;
+      top: 0;
+      left: 0;
+      transform: none;
+      z-index: auto;
+      filter: none;
+    }
+
+    > .modal-header {
+      display: none;
+    }
+
+    > .modal-content {
+      @include desktop {
+        padding: 0;
+        overflow: visible;
+      }
+    }
+
+    > .modal-actions {
+      @include desktop {
+        padding-right: 0;
+        padding-left: 0;
+        border: 0;
+      }
+    }
+  }
+
+  > .modal-overlay {
+    display: none;
+  }
+
+  form {
+    // style first level labels as headings
+    > .form-item > label,
+    > fieldset.form-item > legend {
+      @extend %h3;
+    }
+
+    > fieldset {
+      padding: 0;
+      border: 0;
+    }
+  }
+
+  .label-optional {
+    display: none;
+  }
+
+  .filter__submit {
+    margin-top: .8rem;
+    margin-bottom: .8rem;
   }
 }


### PR DESCRIPTION
Since the section gets uplifted to the root on mobile.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Error:
![image](https://user-images.githubusercontent.com/31842807/76985284-48e4d080-6940-11ea-8917-e9fddcb5fb24.png)
Fixed:
![image](https://user-images.githubusercontent.com/31842807/76985260-3ff3ff00-6940-11ea-963d-1fc717218c45.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
