### PR TITLE
STIJ-303: Fixed scrollable region without keyboard access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this style guide are documented here.
   instead of `'.responsive-table'` to fix WCAG scrollable content violation.
 * Fixed fieldset styling in filter layout modal. Make sure the `.filter-section`
   also has class `sidebar`.
+* Modal fixed-height had a scrollable region without keyboard access.
+  The template has been updated, make sure to add `tabindex=0` on all your
+  `.modal--fixed-height` templates in your project too.
 
 ### Updated
 

--- a/components/00-settings/_vars.scss
+++ b/components/00-settings/_vars.scss
@@ -95,7 +95,8 @@ $z-layers: (
     'base': 6, // creates new stacking context
     'overlay': -1,
     'content': 1,
-    'actions': 2 // iOS fix
+    'actions': 2, // iOS fix
+    'inner': 3
   )
 ) !default;
 

--- a/components/31-molecules/modal/README.md
+++ b/components/31-molecules/modal/README.md
@@ -37,7 +37,9 @@ The default modal has a modal box whose height automatically adapts to the lengt
 
 The fixed-height modal has a modal box whose height is fixed to a height relative to the height of the viewport. The position of the modal box is fixed. The modal box is always centered in the viewport.
 
-When the content or functionality inside the modal box is too long to be shown all in the available height, scrolling of the content or functionality *inside* the modal box is enabled. In this case, only the modal content scrolls, the modal header and the model actions panel stay are pinned to the modal box and stay in place.
+When the content or functionality inside the modal box is too long to be shown all in the available height, scrolling of the content or functionality *inside* the modal box is enabled. In this case, only the modal content scrolls, the modal header and the model actions panel stay are pinned to the modal box and stay in place.  
+
+**Make sure to add `tabindex=0` to the `.modal--fixed-height` element to enable the scrollable region with keyboard access.**
 
 ## Usage within the style guide
 

--- a/components/31-molecules/modal/_modal.scss
+++ b/components/31-molecules/modal/_modal.scss
@@ -49,6 +49,7 @@
       > .modal-content {
         flex-grow: 1;
         margin-bottom: 3.8rem;
+        z-index: z('modal', 'inner');
         overflow-y: auto;
       }
 

--- a/components/31-molecules/modal/modal.twig
+++ b/components/31-molecules/modal/modal.twig
@@ -14,7 +14,7 @@
         <span>Close</span>
       </button>
     </div>
-    <div class="modal-content">
+    <div class="modal-content" {{ modifier == "fixed-height" ? 'tabindex="0"' : '' }}>
       {% if title %}
       <{{ title_heading_level|default('h3') }} id="{{ id }}-title">{{ title }}</{{ title_heading_level|default('h3') }}>
       {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This was an accessibility violation: scrollable regions without focusable elements should have keyboard access.
(updated the z-index to make the focus-outline more visible)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
