### PR TITLE
STIJ-309: Add hash events to the accordion component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ All notable changes to this style guide are documented here.
 * Updated fieldset styling and form-item margins.
 * Radios and checkboxes template has been updated to fix the bottom margin.
   Add a **form-item** wrapper around the form-columns, just like for any other form field.
-* Changed book.svg fill color so that it is able to transform to the different theme colors  
+* Changed book.svg fill color so that it is able to transform to the different theme colors.
+* You can now also trigger opening the accordion component by using the URL hash.
 
 ### Removed
 

--- a/components/31-molecules/accordion/README.md
+++ b/components/31-molecules/accordion/README.md
@@ -75,7 +75,9 @@ And a collapsible element with:
 
 By default, the accordion will initiate automatically
 and hide or show the content
-according to the aria-expanded attribute.
+according to the aria-expanded attribute.  
+If the hash in the URL contains a matching ID,
+this element will also be expanded.
 
 For instance:
 

--- a/components/31-molecules/accordion/accordion.config.js
+++ b/components/31-molecules/accordion/accordion.config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  preview: '@preview-accordion',
   variants: [
     {
       name: 'default',

--- a/components/31-molecules/accordion/accordion.functions.js
+++ b/components/31-molecules/accordion/accordion.functions.js
@@ -210,8 +210,11 @@
      */
     const hashEvent = () => {
       let hash = window.location.hash.replace('#', '');
+      if (!hash) {
+        return;
+      }
       const trigger = elem.querySelector(`[aria-controls=${hash}]`);
-      if (hash && trigger) {
+      if (trigger) {
         open(trigger);
         trigger.focus();
       }

--- a/components/31-molecules/accordion/accordion.functions.js
+++ b/components/31-molecules/accordion/accordion.functions.js
@@ -132,14 +132,16 @@
           window.addEventListener('resize', onResize);
         }
       }
+
+      window.addEventListener('hashchange', hashEvent);
     };
 
     /**
      * Hide or show the accordion content.
      *
      * @param {Object} button  The accordion button.
-     * @param {boolean|false} isInitial  True if this is the first run triggered by
-     *   init().
+     * @param {boolean|false} isInitial  True if this is the first run
+     *   triggered by init().
      */
     const setVisibility = (button, isInitial) => {
 
@@ -175,14 +177,23 @@
       }
     };
 
+    const close = (button) => {
+      button.setAttribute('aria-expanded', 'false');
+      setVisibility(button);
+    };
+
     /**
      * Closes all accordion items.
      */
     const closeAll = () => {
       for (let i = buttons.length; i--;) {
-        buttons[i].setAttribute('aria-expanded', 'false');
-        setVisibility(buttons[i]);
+        close(buttons[i]);
       }
+    };
+
+    const open = (button) => {
+      button.setAttribute('aria-expanded', 'true');
+      setVisibility(button);
     };
 
     /**
@@ -190,8 +201,19 @@
      */
     const openAll = () => {
       for (let i = buttons.length; i--;) {
-        buttons[i].setAttribute('aria-expanded', 'true');
-        setVisibility(buttons[i]);
+        open(buttons[i]);
+      }
+    };
+
+    /**
+     * Open the accordion-content related to the location hash.
+     */
+    const hashEvent = () => {
+      let hash = window.location.hash.replace('#', '');
+      const trigger = elem.querySelector(`[aria-controls=${hash}]`);
+      if (hash && trigger) {
+        open(trigger);
+        trigger.focus();
       }
     };
 
@@ -201,6 +223,7 @@
     const init = () => {
       setInitial();
       addEvents();
+      hashEvent();
     };
 
     if (options.init !== false) {

--- a/components/_preview-accordion.twig
+++ b/components/_preview-accordion.twig
@@ -1,0 +1,34 @@
+{% extends '_preview.twig' %}
+
+{% block content %}
+  <div class="container">
+    <div class="preview-container">
+      {% if _target.isCollated %}
+        <dl class="styleguide">
+          {{ yield | raw }}
+        </dl>
+      {% else %}
+        <div class="content-container">
+          {{ yield | raw }}
+        </div>
+      {% endif %}
+
+      <p class="form-disclaimer">The accordion component uses the hash in you URL to show the relevant content.<br>
+      The below table of contents is not part of the accordion template,
+      but allows you to play with this hash functionality.</p>
+      {% include '@table-of-contents' with {
+        list: [
+          '<a href="#accordion--single--content--1">single accordion</a>',
+          '<a href="#accordion--multiple--content--1">first item</a>',
+          '<a href="#accordion--multiple--content--2">second item</a>',
+          '<a href="#accordion--multiple--content--3">third item</a>',
+          '<a href="#accordion--multiple--content--4">forth item</a>',
+          '<a href="#just_some_random_hash">non existing item</a>'
+        ]
+      } %}
+    </div>
+  </div>
+
+
+{% endblock %}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
You can now trigger opening the accordion by using the URL hash.

@mattiasberlamont 
I've added a specific preview layout in order to demonstrate this option and updated the documentation for this component.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/31842807/77232821-9319bc00-6ba3-11ea-8cd9-710484d56a6c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
