### PR TITLE
STIJ-355: Fixed background accolade in contact-details context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this style guide are documented here.
 
+## [3.0.3]
+
+### Fixed
+
+* Fixed background accolade in contact-details context.
+
 ## [3.0.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this style guide are documented here.
 
-## [3.0.3]
+## [Unreleased]
 
 ### Fixed
 

--- a/components/31-molecules/contact-details/_contact-details.scss
+++ b/components/31-molecules/contact-details/_contact-details.scss
@@ -36,7 +36,7 @@ $avatar-width: 14rem;
     .accolade {
       &::before,
       &::after {
-        @include theme('background', 'color-secondary', 'highlight-background');
+        @include theme('background', 'color-secondary', 'contact-details-inverted-background-color');
       }
     }
   }

--- a/components/31-molecules/contact-details/_contact-details.scss
+++ b/components/31-molecules/contact-details/_contact-details.scss
@@ -32,6 +32,13 @@ $avatar-width: 14rem;
         box-shadow: none;
       }
     }
+
+    .accolade {
+      &::before,
+      &::after {
+        @include theme('background', 'color-secondary', 'highlight-background');
+      }
+    }
   }
 
   &-column {

--- a/components/31-molecules/highlight/_highlight.scss
+++ b/components/31-molecules/highlight/_highlight.scss
@@ -35,7 +35,7 @@
   .accolade {
     &::before,
     &::after {
-      @include theme('background', 'color-primary--lighten-5', 'highlight-background');
+      @include theme('background', 'color-primary--lighten-5', 'highlight-inverted-background');
     }
   }
 }

--- a/components/31-molecules/highlight/_highlight.scss
+++ b/components/31-molecules/highlight/_highlight.scss
@@ -35,7 +35,7 @@
   .accolade {
     &::before,
     &::after {
-      @include theme('background', 'color-primary--lighten-5', 'highlight-inverted-background');
+      @include theme('background', 'color-primary--lighten-5', 'highlight-background');
     }
   }
 }


### PR DESCRIPTION
## Description
Updated scss of contact details component.

## Motivation and Context
Add an inverted background for accolade component in the context of contact-details highlight block.

## How Has This Been Tested?
Manual tested in KotAtGent.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
