### PR TITLE
STIJ-354: Fixed Read more links hidden text order.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this style guide are documented here.
 ### Fixed
 
 * Fixed background accolade in contact-details context.
+* Fixed teaser hidden read more text order.  
+  'Read more' links should be **followed** by a hidden text, not preceded.  
+  This was incorrect in our templates.  
+  Please check your projects to see if you had copied this error.  
+  The correct template is:
+  ```html
+     <a href="#" class="read-more standalone-link">
+       Read more
+       <span class="visually-hidden">about {{ usually the title of the teaser }}</span>
+     </a>
+  ```
 
 ## [3.0.2]
 

--- a/components/21-atoms/link/link.twig
+++ b/components/21-atoms/link/link.twig
@@ -15,12 +15,12 @@
   {% if title %}
    title="{{ title }}"
   {% endif %} >
-  {% if labeled_by %}
-    <span class="visually-hidden">
-      {{ labeled_by }}
-    </span>
-  {% endif %}
   {% spaceless %}
       {{ text }}
   {% endspaceless %}
+  {% if hidden_read_more %}
+      <span class="visually-hidden">
+          {{ hidden_read_more }}
+      </span>
+  {% endif %}
 </a>

--- a/components/31-molecules/teaser/teaser--teaser--wide.twig
+++ b/components/31-molecules/teaser/teaser--teaser--wide.twig
@@ -49,7 +49,7 @@
         'link': link,
         'modifier': 'read-more standalone-link',
         'title': null,
-        'labeled_by': 'about '~title
+        'hidden_read_more': 'about '~title
       } %}
     </div>
 

--- a/components/31-molecules/teaser/teaser.twig
+++ b/components/31-molecules/teaser/teaser.twig
@@ -54,7 +54,7 @@
           'text': 'Read more',
           'link': link,
           'modifier': 'read-more standalone-link',
-          'labeled_by': 'about '~title
+          'hidden_read_more': 'about '~title
         } %}
       {% endif %}
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
  'Read more' links should be **followed** by a hidden text, not preceded.  
  This was incorrect in our templates.  
  The correct template is:
  ```html
     <a href="#" class="read-more standalone-link">
       Read more
       <span class="visually-hidden">about {{ usually the title of the teaser }}</span>
     </a>
  ```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
