### PR TITLE
STIJ-361: Fixed modal-content not visible in IE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this style guide are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+* Content of the mobile menu was not visible when using Internet Explorer.
+
 ## [3.1.0]
 
 ### Added

--- a/components/31-molecules/modal/_modal.scss
+++ b/components/31-molecules/modal/_modal.scss
@@ -98,13 +98,11 @@
       &:first-of-type {
         border-top-left-radius: border-radius('radius-2');
         border-top-right-radius: border-radius('radius-2');
-        overflow: hidden;
       }
 
       &:last-of-type {
         border-bottom-left-radius: border-radius('radius-2');
         border-bottom-right-radius: border-radius('radius-2');
-        overflow: hidden;
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed overflow:hidden

## Motivation and Context
Modal-content was not visible in IE

## How Has This Been Tested?
I've checked several variations of the modal and menu, removing overflow:hidden does not seem to have any undesired impact.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
