### PR TITLE
SGD8-2490: Fix mobile styling and with it the padding problem

### DIFF
--- a/components/31-molecules/highlight/_highlight.scss
+++ b/components/31-molecules/highlight/_highlight.scss
@@ -5,13 +5,22 @@
   .highlight__inner {
     @include theme('background-color', 'color-tertiary--lighten-5', 'highlight-background');
     @include theme-content('color-tertiary--lighten-3', 'highlight-shadow-color') {
-      @include abstract-shadow('bottom', 'right', $theme-color);
+      @include abstract-shadow('bottom', 'right', $theme-color, null, 9.5rem, 9.5rem);
+
+      @include phablet {
+        @include abstract-shadow('bottom', 'right', $theme-color, null, 11rem, 11rem);
+      }
     }
 
-    padding: 3rem;
+    padding: 1rem;
+    min-height: 22rem;
+
+    @include phablet {
+      min-height: 13.8rem;
+    }
 
     @include tablet {
-      padding: 2rem;
+      padding: 3rem;
     }
 
     > i {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I changed the styling as the reason the padding was incorrect is because the padding should actually be reversed (mobile first and then larger screen).

I adjusted this and then added the mobile styling as well, since it didn't appear to be there yet.

Finally I simply made the change to the square and added mobile styling for this as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
