### PR TITLE
SGD8-2490: More padding on mobile, remove min height property, smaller margin between title and text

### DIFF
--- a/components/31-molecules/highlight/_highlight.scss
+++ b/components/31-molecules/highlight/_highlight.scss
@@ -12,12 +12,7 @@
       }
     }
 
-    padding: 1rem;
-    min-height: 22rem;
-
-    @include phablet {
-      min-height: 13.8rem;
-    }
+    padding: 1.5rem;
 
     @include tablet {
       padding: 3rem;
@@ -37,6 +32,7 @@
     h3 {
       display: inline-block;
       margin-top: 0;
+      margin-bottom: 1rem;
     }
 
     > *:last-child {


### PR DESCRIPTION
…ke margin smaller between title and text

<!--- Provide a general summary of your changes in the Title above -->

## Description
After a code review I received the comment that it is better to just let the heigt depend on the amount of content entered especially on mobile where space on the screen is limited, therefore I removed the min heigt property.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
