### PR TITLE
SGDB-2514: switch to apply spaceless filter

### DIFF
--- a/components/21-atoms/image/image.twig
+++ b/components/21-atoms/image/image.twig
@@ -1,4 +1,4 @@
-{% spaceless %}
+{% apply spaceless %}
   <figure {% if modifier %} class="{{ modifier }}" {% endif %}>
     {% if ratio %}
       <div class="image-wrapper" data-ratio="{{ ratio }}">
@@ -25,4 +25,4 @@
     {% endif %}
 
   </figure>
-{% endspaceless %}
+{% endapply %}

--- a/components/21-atoms/link/link.twig
+++ b/components/21-atoms/link/link.twig
@@ -16,9 +16,9 @@
     {% if title %}
       title="{{ title }}"
     {% endif %} >
-    {% spaceless %}
+    {% apply spaceless %}
       {{ text }}
-    {% endspaceless %}
+    {% endapply %}
     {% if hidden_read_more %}
       <span class="visually-hidden">
         {{ hidden_read_more }}

--- a/components/31-molecules/breadcrumbs/breadcrumbs.twig
+++ b/components/31-molecules/breadcrumbs/breadcrumbs.twig
@@ -2,11 +2,11 @@
   <div class="content-container">
     <h2 id="{{ id|default('system-breadcrumb--' ~ _self.name) }}" class="visually-hidden">{{ 'Breadcrumb' }}</h2>
     <ol class="no-style">
-      {% spaceless %}
+      {% apply spaceless %}
         {% for item in items %}
           <li>{{ item }}</li>
         {% endfor %}
-      {% endspaceless %}
+      {% endapply %}
     </ol>
   </div>
 </nav>

--- a/components/31-molecules/form-steps/form-steps.twig
+++ b/components/31-molecules/form-steps/form-steps.twig
@@ -1,6 +1,6 @@
 <nav class="form-steps{{ modifier ? ' ' ~ modifier }}" aria-labelledby="form-steps-{{ steps.length }}{{ active }}{{ modifier ? '-' ~ modifier }}">
   <h2 id="form-steps-{{ steps.length }}{{ active }}{{ modifier ? '-' ~ modifier }}" class="visually-hidden">Steps in this wizard</h2>
-  {% spaceless %}
+  {% apply spaceless %}
     <ol class="form-steps-list">
       {% for key, step in steps %}
         <li class="{% if key + 1 < active %}completed{% endif %}{% if key + 1 == active %}active{% endif %}">
@@ -12,5 +12,5 @@
         </li>
       {% endfor %}
     </ol>
-  {% endspaceless %}
+  {% endapply %}
 </nav>

--- a/components/31-molecules/pagination/pagination.twig
+++ b/components/31-molecules/pagination/pagination.twig
@@ -1,6 +1,6 @@
 <nav class="pager" aria-labelledby="pagination_1-{{ total ~ active }}">
   <h2 id="pagination_1-{{ total ~ active }}" class="visually-hidden">Pagination</h2>
-  {% spaceless %}
+  {% apply spaceless %}
     <ul class="pager__items">
 
       {% if 1 != active %}
@@ -82,6 +82,6 @@
         </li>
       {% endif %}
     </ul>
-  {% endspaceless %}
+  {% endapply %}
 </nav>
 


### PR DESCRIPTION
## Description
- Spaceless filter used with apply (deprecated in Twig 2.7)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
