### PR TITLE
SGDB-2466: margin-right for group Ghent links removed

### DIFF
--- a/components/21-atoms/link/_link.scss
+++ b/components/21-atoms/link/_link.scss
@@ -274,8 +274,12 @@ a {
   &[href^="http://"],
   &[href^="https://"] {
     &[href*="stad.gent"] {
-      &:not([download]):not(.standalone-link)::after {
-        content: none;
+      &:not([download]):not(.standalone-link) {
+        margin-right: 0;
+
+        &::after {
+          content: none;
+        }
       }
 
       ///


### PR DESCRIPTION
## Description
margin-right for group Ghent links removed, based on problem in ticket https://district09.atlassian.net/browse/SGD8-2490

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
