### PR TITLE
SDG8-2469: fix breadcrumb alignment

### DIFF
--- a/components/31-molecules/breadcrumbs/_breadcrumbs.scss
+++ b/components/31-molecules/breadcrumbs/_breadcrumbs.scss
@@ -64,24 +64,27 @@
 
   .expandable {
     a {
-      @include reset-link-background;
       @include bold-text;
-      @include theme('border-color', 'color-primary', 'breadcrumb-expandable-color');
 
-      top: -3px;
-      padding: .2rem .3rem .4rem;
-      border: 2px solid;
-      line-height: .3rem;
+      padding: 0 .35rem;
+      border-color: transparent;
+      outline: 2px solid currentColor;
+      line-height: 0.95rem;
 
       &:hover,
       &:focus {
         @include theme('background-color', 'color-primary--lighten-4', 'link-hover-background');
       }
+
+      &,
+      &:focus,
+      &:hover {
+        background-image: none;
+      }
     }
 
-    &::after {
-      position: relative;
-      top: -2px;
+    &:after {
+      line-height: inherit;
     }
   }
 


### PR DESCRIPTION
## Description
- fixed the alignment for the breadcrumb by using outline instead of border
- transparent border for alignment purposes in Firefox

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
