### PR TITLE
STIJ-437: Update allieTabs to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@digipolis-gent/modal": "^1.0.4",
         "acorn": "^8.8.2",
-        "allietabs": "^1.2.5",
+        "allietabs": "^1.2.6",
         "baguettebox.js": "^1.11.1",
         "breakpoint-sass": "^3.0.0",
         "debug": "^4.3.4",
@@ -31,7 +31,7 @@
         "@babel/preset-env": "^7.20.2",
         "@frctl/fractal": "^1.5.15",
         "@frctl/twig": "^1.2.13",
-        "chromedriver": "^109.0.0",
+        "chromedriver": "^117.0.0",
         "cssnano": "^5.1.14",
         "fs-extra": "^11.1.0",
         "gulp": "^4.0.2",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/allietabs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/allietabs/-/allietabs-1.2.5.tgz",
-      "integrity": "sha512-AXLYRHLgxRSjXpyUir3Hait5DstFZu58BX9PACHc0OFDxZhngVtoqVmqiKemFBcMLMbXUghEAdZ7jo/7IFgggA=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/allietabs/-/allietabs-1.2.6.tgz",
+      "integrity": "sha512-682TPhOlXVEtX7Ma19ezRuKvb0RRlXTUaBSBhcyDCOiXjdTaKK4QgSa98hPaw2bpgZ1hWsMj+L9XlzJBbNGk6w=="
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -3211,9 +3211,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
-      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "devOptional": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -5305,15 +5305,15 @@
       "dev": true
     },
     "node_modules/chromedriver": {
-      "version": "109.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-109.0.0.tgz",
-      "integrity": "sha512-jdmBq11IUwfThLFiygGTZ89qbROSQI4bICQjvOVQy2Bqr1LwC+MFkhwyZp3YG99eehQbZuTlQmmfCZBfpewTNA==",
+      "version": "117.0.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.2.tgz",
+      "integrity": "sha512-BAapkOzJNKe65EpCe8OXcdhSwop8CZuf09I7rGC0SKQgcjNAFH18CwOIO0I0yH8MtC5GyLjoWybV7A2CPFyeZA==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -5323,7 +5323,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -5779,9 +5779,9 @@
       "devOptional": true
     },
     "node_modules/compare-versions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
       "devOptional": true
     },
     "node_modules/component-emitter": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/preset-env": "^7.20.2",
     "@frctl/fractal": "^1.5.15",
     "@frctl/twig": "^1.2.13",
-    "chromedriver": "^109.0.0",
+    "chromedriver": "^117.0.0",
     "cssnano": "^5.1.14",
     "fs-extra": "^11.1.0",
     "gulp": "^4.0.2",
@@ -52,7 +52,7 @@
   "dependencies": {
     "@digipolis-gent/modal": "^1.0.4",
     "acorn": "^8.8.2",
-    "allietabs": "^1.2.5",
+    "allietabs": "^1.2.6",
     "baguettebox.js": "^1.11.1",
     "breakpoint-sass": "^3.0.0",
     "debug": "^4.3.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the allietabs dependency to 1.2.6.

## Motivation and Context
See https://github.com/BartDelrue/allieTabs/issues/19

## How Has This Been Tested?
Checked the build/styleguide/vendor/allietabs/allieTabs.js file after the build process to see if the line was still present. It wasn't.

## Screenshots (if appropriate):
/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
