### PR TITLE
SGD8-2500: Add lineheight to icon + overflow hidden

### DIFF
--- a/components/31-molecules/accordion/_accordion.scss
+++ b/components/31-molecules/accordion/_accordion.scss
@@ -15,6 +15,7 @@
       right: 0;
       transition: transform .2s ease-in-out;
       font-size: 1.4rem;
+      line-height: 1.2;
     }
 
     &[aria-expanded=true] {
@@ -26,6 +27,7 @@
 
   .accordion--content {
     transition: max-height .5s ease-in-out;
+    overflow: hidden;
 
     p {
       line-height: 1.75;
@@ -65,7 +67,6 @@ dl.accordion {
       padding: .13rem .25rem;
       transition: transform .2s ease-in-out;
       font-size: 1.2rem;
-      line-height: 1.2;
       text-align: left;
     }
 
@@ -74,11 +75,16 @@ dl.accordion {
 
       &::before {
         transform: none;
+        line-height: 1.2;
       }
     }
 
     &[aria-expanded=false] {
       @include icon(plus);
+
+      &::before {
+        line-height: 1.2;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
- line-height added to btn before
- overflow hidden added to accordion content

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
