### PR TITLE
SGD8-2490: Change link icon back to inline

### DIFF
--- a/components/00-mixins/link/_link.scss
+++ b/components/00-mixins/link/_link.scss
@@ -23,7 +23,7 @@
 ///
 @mixin link-background($underline, $hover: null, $underline-exception: null, $hover-exception: null) {
   @include theme('border-color', $underline, $underline-exception);
-  transition: background-image 1s;
+  transition: background-image 1s, color 1s;
   border-bottom: 2px solid;
   background-repeat: repeat-y;
   background-position: 0 100%;
@@ -34,7 +34,7 @@
         $theme-color 0,
         $theme-color 100%);
     }
-    transition: background-size .2s;
+    transition: background-size .2s, color .2s;
     background-size: 0 100%;
 
     &:hover,

--- a/components/21-atoms/link/_link.scss
+++ b/components/21-atoms/link/_link.scss
@@ -10,6 +10,17 @@ a {
   text-decoration: none;
   word-wrap: break-word;
 
+  &::before,
+  &::after {
+    display: inline-block;
+    margin-left: 5px;
+    transition: margin .1s ease-in;
+    border: 0;
+    font-size: 1.3em;
+    line-height: 1.4em;
+    vertical-align: -25%;
+  }
+
   // Different button link types. These are links styled as a button.
   &.button,
   &.tag {
@@ -66,21 +77,6 @@ a {
     }
   }
 
-  &::before,
-  &::after {
-    transition: margin .1s ease-in;
-    border: 0;
-    font-size: 1.3em;
-    line-height: 1.4em;
-    vertical-align: -25%;
-  }
-
-  &:not(.button):not(.tag)::after {
-    position: absolute;
-    margin-top: 4px;
-    margin-left: 5px;
-  }
-
   ///
   /// Stand alone links.
   ///
@@ -93,9 +89,9 @@ a {
       @include theme('color', 'color-primary--darken-2', 'link-hover-color');
     }
 
-    &::after {
-      margin-top: 2px;
-    }
+    //&::after {
+    //  margin-top: 2px;
+    //}
   }
 
   &.standalone-link:not([href^="mailto:"]):not([href^="tel:"]):not([download]):not([href^="http://"]):not([href^="https://"]):not(.back):not(.refresh),
@@ -106,7 +102,6 @@ a {
 
   &.standalone-link:not([href^="mailto:"]):not([href^="tel:"]):not([download]):not([href^="http://"]):not([href^="https://"]):not(.back):not(.refresh) {
     @include icon(arrow-right, after);
-    margin-right: 1.6rem;
   }
 
   ///
@@ -114,7 +109,6 @@ a {
   ///
   &[download]:not(.no-icon) {
     @include icon(download, after);
-    margin-right: 1.6rem;
   }
 
   ///
@@ -122,7 +116,6 @@ a {
   ///
   &[href^="mailto:"]:not(.no-icon) {
     @include icon(envelope, after);
-    margin-right: 1.6rem;
   }
 
   ///
@@ -130,7 +123,6 @@ a {
   ///
   &[href^="tel:"]:not(.no-icon) {
     @include icon(phone, after);
-    margin-right: 1.6rem;
   }
 
   ///
@@ -139,7 +131,6 @@ a {
   &[href^="http://"]:not(.no-icon):not(.tag),
   &[href^="https://"]:not(.no-icon):not(.tag) {
     @include icon(arrow-right-top, after);
-    margin-right: 1.6rem;
 
     &[download]:not(.button):not(.no-icon) {
       @include icon(download, after);
@@ -149,12 +140,17 @@ a {
   &.refresh:not(.no-icon),
   &.back:not(.no-icon) {
     @extend %a-arrow-animation--left;
-    margin-left: 1.6rem;
+    margin-left: 32px;
     padding-left: 0;
 
     &::after {
       position: absolute;
-      left: -40px;
+      top: 0;
+      bottom: 0;
+      left: -44px;
+      height: 24px;
+      margin-top: auto;
+      margin-bottom: auto;
       padding-right: 4px;
       padding-left: 8px;
     }
@@ -176,10 +172,6 @@ a {
     &:hover,
     &:focus {
       @include theme('color', 'color-primary');
-
-      &::after {
-        @include theme('color', 'color-none');
-      }
     }
   }
 }

--- a/components/21-atoms/link/_link.scss
+++ b/components/21-atoms/link/_link.scss
@@ -89,9 +89,6 @@ a {
       @include theme('color', 'color-primary--darken-2', 'link-hover-color');
     }
 
-    //&::after {
-    //  margin-top: 2px;
-    //}
   }
 
   &.standalone-link:not([href^="mailto:"]):not([href^="tel:"]):not([download]):not([href^="http://"]):not([href^="https://"]):not(.back):not(.refresh),

--- a/components/31-molecules/pagination/_pagination.scss
+++ b/components/31-molecules/pagination/_pagination.scss
@@ -96,6 +96,15 @@
 
       a {
         padding-right: 0;
+
+        &::after {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          height: 24px;
+          margin-top: auto;
+          margin-bottom: auto;
+        }
       }
     }
 
@@ -110,6 +119,10 @@
 
       a {
         margin-left: 0;
+
+        &::after {
+          right: -36px;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
- changed absolute positioning back to inline-block
- fixed pagination issue as a result of this
- fixed color (blinking) transition for link-background

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
