### PR TITLE
Fix duplicate focus outline in opening hours month widget.

### DIFF
--- a/components/31-molecules/opening-hours/_opening-hours.scss
+++ b/components/31-molecules/opening-hours/_opening-hours.scss
@@ -188,6 +188,7 @@ $week-breakpoint: '(min-width: 750px)';
 
       &--day-open,
       &--day-closed {
+        outline-offset: 0;
         cursor: pointer;
 
         &[tabindex='0'] > span,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I noticed a duplicate focus outline in the existing opening hours widget on [gent sport](https://stad.gent/nl/sport/aanbod/sportlocaties/zwembad-strop).

![image](https://github.com/StadGent/fractal_styleguide_gent-base/assets/31842807/8bfc7949-758c-4227-97bf-4aa3e12180d7)

The same issue persist in styleguide v6
![image](https://github.com/StadGent/fractal_styleguide_gent-base/assets/31842807/c05df40a-9b35-48d4-93ae-d082a0f9fcd0)

I've changed the focus outline to 0 so it enforces the already existing border.  
If not, a keyboard user would not see the difference between the selected date and the 'focused selected date'.   
This is best tested in a working version of the opening hours widget.

![image](https://github.com/StadGent/fractal_styleguide_gent-base/assets/31842807/4b529b79-3bdc-48cb-9e9c-077d473dbb8b)


My congratulations on the redesign BTW 🥳  
It's slick! (and much less "aquarel duplo" 😉)  

## Motivation and Context

It looked broken and I was feeling nostalgic.

## How Has This Been Tested?

Mouse and keyboard test in the fractal live server, using Mozilla Firefox.
Applied the same style changes on the production site, same desired effect.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
