### PR TITLE
SGD8-2590: Fix focus outline for icons

### DIFF
--- a/components/11-base/fonts/templates/_icons.template
+++ b/components/11-base/fonts/templates/_icons.template
@@ -28,7 +28,7 @@ $id: random(1000);
   font-size: 1.2rem;
   font-variant: normal;
   font-weight: normal;
-  line-height: 100%;
+  line-height: 87.5%;
   speak: none; // only necessary if not using the private unicode range (firstGlyph option)
   text-decoration: none;
   text-transform: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Change line-height for icons so that the focus outline isn't wonky
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
