### PR TITLE
SGD8-2563: Add timeline-slot-reverse option

### DIFF
--- a/components/41-organisms/timeline/_timeline.scss
+++ b/components/41-organisms/timeline/_timeline.scss
@@ -166,7 +166,6 @@ dl.timeline {
         padding-right: calc(#{$gutter-width*.5});
         padding-bottom: $timeline-dd-space-between-mobile;
         padding-left: calc(#{$timeline-m-left-padding} + #{$timeline-m-right-padding});
-        grid-area: left;
 
         @include desktop {
           padding-bottom: $timeline-dd-space-between;
@@ -232,79 +231,166 @@ dl.timeline {
         }
       }
 
-      // Alternating timeline-slots get alternating styling (left/right).
-      &:nth-of-type(odd):not(.item--left),
-      &.item--right {
-        .item__image-desktop {
-          @include desktop {
-            padding-right: 66px;
-            padding-left: calc(#{$gutter-width*.5});
-
-            &::after {
-              display: none;
-            }
-          }
-        }
-
-        .item__content {
-          @include desktop {
-            padding-right: calc(#{$gutter-width*.5});
-            padding-left: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
-            grid-area: right;
-          }
-        }
-      }
-
-      &:nth-of-type(even):not(.item--right),
-      &.item--left {
-        .item__image-desktop {
-          @include desktop {
-            padding-right: calc(#{$gutter-width*.5});
-            padding-left: 66px;
-            grid-area: right;
-          }
-        }
-
-        .item__content {
-          @include desktop {
-            padding-right: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
-            padding-left: calc(#{$gutter-width*.5});
-            text-align: right;
-
-            .timeline-slot-title {
-              button {
-                justify-content: flex-end;
-                margin: 0 0 0 55px;
-                padding: 0 55px 0 0;
-
-                // +/- icon
-                &::before {
-                  right: 0;
-                  left: auto;
-                  margin: 0 0 0 15px;
-                  padding-right: 4px;
-                }
-
-                &::after {
-                  right: auto;
-                  left: 100%;
-                }
-              }
-            }
-
-            &::after {
-              display: none;
-            }
-          }
-        }
-      }
-
       &:first-of-type {
         & > dd {
           padding-top: $timeline-dd-space-between-mobile;
 
           @include desktop {
             padding-top: $timeline-dd-space-between;
+          }
+        }
+      }
+    }
+
+    &:not(.timeline-slot-reverse) {
+      .item {
+
+
+        // Alternating timeline-slots get alternating styling (left/right).
+        &:nth-of-type(odd):not(.item--left),
+        &.item--right {
+          .item__image-desktop {
+            @include desktop {
+              padding-right: 66px;
+              padding-left: calc(#{$gutter-width*.5});
+              grid-area: left;
+
+              &::after {
+                display: none;
+              }
+            }
+          }
+
+          .item__content {
+            @include desktop {
+              padding-right: calc(#{$gutter-width*.5});
+              padding-left: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
+              grid-area: right;
+            }
+          }
+        }
+
+        &:nth-of-type(even):not(.item--right),
+        &.item--left {
+          .item__image-desktop {
+            @include desktop {
+              padding-right: calc(#{$gutter-width*.5});
+              padding-left: 66px;
+              grid-area: right;
+            }
+          }
+
+          .item__content {
+            @include desktop {
+              padding-right: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
+              padding-left: calc(#{$gutter-width*.5});
+              text-align: right;
+              grid-area: left;
+
+              .timeline-slot-title {
+                button {
+                  justify-content: flex-end;
+                  margin: 0 0 0 55px;
+                  padding: 0 55px 0 0;
+
+                  // +/- icon
+                  &::before {
+                    right: 0;
+                    left: auto;
+                    margin: 0 0 0 15px;
+                    padding-right: 4px;
+                  }
+
+                  &::after {
+                    right: auto;
+                    left: 100%;
+                  }
+                }
+              }
+
+              &::after {
+                display: none;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    &.timeline-slot-reverse {
+      .item {
+        & > dd {
+          padding-right: calc(#{$timeline-m-left-padding} + #{$timeline-m-right-padding});
+          padding-left: calc(#{$gutter-width*.5});
+          grid-area: right;
+        }
+
+        // Alternating timeline-slots get alternating styling (left/right).
+        &:nth-of-type(even):not(.item--right),
+        &.item--left {
+          .item__image-desktop {
+            @include desktop {
+              padding-right: 66px;
+              padding-left: calc(#{$gutter-width*.5});
+              grid-area: left;
+
+              &::after {
+                display: none;
+              }
+            }
+          }
+
+          .item__content {
+            @include desktop {
+              padding-right: calc(#{$gutter-width*.5});
+              padding-left: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
+              grid-area: right;
+            }
+          }
+        }
+
+        &:nth-of-type(odd):not(.item--left),
+        &.item--right {
+          .item__image-desktop {
+            @include desktop {
+              padding-right: calc(#{$gutter-width*.5});
+              padding-left: 66px;
+              grid-area: right;
+            }
+          }
+
+          .item__content {
+            @include desktop {
+              padding-right: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
+              padding-left: calc(#{$gutter-width*.5});
+              text-align: right;
+              grid-area: left;
+
+              .timeline-slot-title {
+                button {
+                  justify-content: flex-end;
+                  margin: 0 0 0 55px;
+                  padding: 0 55px 0 0;
+
+                  // +/- icon
+                  &::before {
+                    right: 0;
+                    left: auto;
+                    margin: 0 0 0 15px;
+                    padding-right: 4px;
+                  }
+
+                  &::after {
+                    right: auto;
+                    left: 100%;
+                  }
+                }
+              }
+
+              &::after {
+                display: none;
+              }
+            }
           }
         }
       }

--- a/components/41-organisms/timeline/timeline.twig
+++ b/components/41-organisms/timeline/timeline.twig
@@ -8,7 +8,7 @@
         <h3 class="dt-title">Paragraph title</h3>
       </dt>
       {# Timeline item BEGIN #}
-      <div class="item item--right">
+      <div class="item">
         <dd class="item__content">
           <div class="timeline-slot-header">
             {# Timeline item title #}
@@ -63,7 +63,7 @@
         </dd>
       </div>
       {# Timeline item END #}
-      <div class="item item--left">
+      <div class="item">
         <dd class="item__content">
           <div class="timeline-slot-header">
             <h4 class="timeline-slot-title">
@@ -114,6 +114,60 @@
           </div>
         </dd>
       </div>
+      <div class="item">
+        <dd class="item__content">
+          <div class="timeline-slot-header">
+            {# Timeline item title #}
+            <h4 class="timeline-slot-title">
+              <button aria-expanded="true" aria-controls="timeline-slot-content--10"
+                      data-controls-img="timeline-slot-img--10" class="accordion--button">
+                Timeline item title
+              </button>
+            </h4>
+            {# Timeline item subtitle #}
+            <h5 class="timeline-slot-date">Timeline item subtitle/date</h5>
+          </div>
+          <div class="timeline-slot-content accordion--content accordion--expanded" id="timeline-slot-content--10" aria-hidden="false">
+            <div class="content-image hidden-desktop">
+              {# This is the same image as above #}
+              {% include '@image-gallery--single' with {
+
+                "items": [
+                  {
+                    "src": "https://via.placeholder.com/800x500&text=8:5+(800x500)",
+                    "alt": "placeholder image alternative text",
+                    "caption": "image caption"
+                  }
+                ]
+              } %}
+            </div>
+            {# Timeline item text #}
+            {% include '@paragraph' with {
+              'text': 'This is the base font. Cake caramels jelly-o lemon drops gummies. Apple pie carrot cake pie powder ice cream icing sweet roll. Caramels chocolate gummies cotton candy dessert apple pie pastry gingerbread. Jelly beans toffee macaroon sweet roll.'
+            } %}
+            <ol>
+              <li>Candy lollipops</li>
+              <li>Sugar sweetness</li>
+              <li>Toffee sticks</li>
+            </ol>
+          </div>
+        </dd>
+        <dd class="item__image-desktop show-desktop-only">
+          <div class="timeline-slot-content timeline-slot-content__img accordion--content" id="timeline-slot-img--10"
+               aria-hidden="true">
+            {% include '@image-gallery--single' with {
+
+              "items": [
+                {
+                  "src": "https://via.placeholder.com/800x500&text=8:5+(800x500)",
+                  "alt": "placeholder image alternative text",
+                  "caption": "image caption"
+                }
+              ]
+            } %}
+          </div>
+        </dd>
+      </div>
     </div>
     {# Timeline paragraph END #}
 
@@ -121,7 +175,7 @@
       <dt>
         <h3 class="dt-title">Paragraph title</h3>
       </dt>
-      <div class="item item--right">
+      <div class="item">
         <dd class="item__content">
           <div class="timeline-slot-header">
             <h4 class="timeline-slot-title">
@@ -171,7 +225,7 @@
           </div>
         </dd>
       </div>
-      <div class="item item--left">
+      <div class="item">
         <dd class="item__content">
           <div class="timeline-slot-header">
             <h4 class="timeline-slot-title">
@@ -226,7 +280,7 @@
       <dt>
         <h3 class="dt-title">Paragraph title</h3>
       </dt>
-      <div class="item item--right">
+      <div class="item">
         <dd class="item__content">
           <div class="timeline-slot-header">
             <h4 class="timeline-slot-title">
@@ -277,11 +331,11 @@
         </dd>
       </div>
     </div>
-    <div class="timeline-slot" role="listitem">
+    <div class="timeline-slot timeline-slot-reverse" role="listitem">
       <dt>
         <h3 class="dt-title">Paragraph title</h3>
       </dt>
-      <div class="item item--left">
+      <div class="item">
         <dd class="item__content">
           <div class="timeline-slot-header">
             <h4 class="timeline-slot-title">
@@ -336,7 +390,7 @@
       <dt>
         <h3 class="dt-title">Paragraph title</h3>
       </dt>
-      <div class="item item--right">
+      <div class="item">
         <dd class="item__content">
           <div class="timeline-slot-header">
             <h4 class="timeline-slot-title">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- add timeline-slot-reverse class and styling
- moved default to :not(timeline-slot-reverse)
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
