### PR TITLE
SGD8-2698: Fix word-break Chrome

### DIFF
--- a/components/21-atoms/link/_link.scss
+++ b/components/21-atoms/link/_link.scss
@@ -9,6 +9,7 @@ a {
   position: relative;
   text-decoration: none;
   word-wrap: break-word;
+  word-break: break-all;
 
   &::before,
   &::after {

--- a/components/31-molecules/breadcrumbs/_breadcrumbs.scss
+++ b/components/31-molecules/breadcrumbs/_breadcrumbs.scss
@@ -5,7 +5,7 @@
   ul,
   ol {
     flex-wrap: wrap;
-    max-width: 100%;
+    max-width: calc(100vw - 40px);
     margin: 0;
     list-style: none;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add word-break for Chromium based browsers (word-wrap doesn't work there)
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
