### PR TITLE
DTGB-904: Fixed styling of modal & filter modal

### DIFF
--- a/components/31-molecules/modal/_modal.scss
+++ b/components/31-molecules/modal/_modal.scss
@@ -53,15 +53,7 @@
       }
 
       > .modal-actions {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        margin-top: -76px;
         padding-top: 30px;
-
-        @include tablet {
-          position: static;
-        }
       }
     }
   }
@@ -149,13 +141,13 @@
     flex-shrink: 0;
     align-items: center;
     width: 100%;
-    padding: 30px 20px 60px;
+    padding: 30px 20px;
     z-index: z('modal', 'actions');
 
     @include tablet {
       position: relative;
       margin-top: -15px;
-      padding: 0 70px 60px;
+      padding: 0 70px 30px;
     }
   }
 

--- a/components/31-molecules/modal/modal.config.js
+++ b/components/31-molecules/modal/modal.config.js
@@ -25,10 +25,25 @@ module.exports = {
   },
   variants: [
     {
+      name: 'fixed-height',
+      context: {
+        id: 'modal-fixed-height',
+        modifier: 'fixed-height'
+      }
+    },
+    {
       name: 'with-actions',
       context: {
         id: 'modal-actions',
         actions: '<button type="button" class="button button-primary modal-close" data-target="modal-actions">Understood!</button>'
+      }
+    },
+    {
+      name: 'with-actions-and-fixed-height',
+      context: {
+        id: 'modal-actions-fixed-height',
+        actions: '<button type="button" class="button button-primary modal-close" data-target="modal-actions">Understood!</button>',
+        modifier: 'fixed-height'
       }
     }
   ]

--- a/components/41-organisms/filter/_filter.scss
+++ b/components/41-organisms/filter/_filter.scss
@@ -115,18 +115,16 @@
     }
 
     > .modal-content {
-      margin-bottom: 30px;
-
       @include desktop {
+        margin-bottom: 30px;
         padding: 0;
         overflow: visible;
       }
     }
 
     > .modal-actions {
-      margin-top: 10px;
-
       @include desktop {
+        margin-top: 10px;
         padding-right: 0;
         padding-left: 0;
         border: 0;


### PR DESCRIPTION
## Description

Fixed flaws in the styling of the modal & filter modal.

## Motivation and Context

- There was a gap in the filter modal (mobile & tablet) due to margins creating a gap between the modal content & actions.
- The content of the modal was not completely visible due to the absolute positioning of the modal-actions.

## How Has This Been Tested?

- Visually tested using the fractal styleguide examples.
- Added extra variant examples so the fixed-height modals are also documented.

## Screenshots (if appropriate):

### Filter on mobile

![DTGB-904-filter-mobile](https://github.com/StadGent/fractal_styleguide_gent-base/assets/133124/9cb1d9f0-78f7-4550-b658-ca5a567b4e8c)

### Filter on tablet

![DTGB-904-filter-tablet](https://github.com/StadGent/fractal_styleguide_gent-base/assets/133124/8faf0b86-b03c-408c-bdfd-f8845745b097)

### Filter on desktop

![DTGB-904-filter-desktop](https://github.com/StadGent/fractal_styleguide_gent-base/assets/133124/8e666155-9b97-4ab5-bbdf-7058108db3ad)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
