### PR TITLE
SGD8-2855: Fix last item + alignment left item

### DIFF
--- a/components/41-organisms/timeline/_timeline.scss
+++ b/components/41-organisms/timeline/_timeline.scss
@@ -286,7 +286,6 @@ dl.timeline {
             @include desktop {
               padding-right: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
               padding-left: calc(#{$gutter-width*.5});
-              text-align: right;
               grid-area: left;
 
               .timeline-slot-title {
@@ -308,6 +307,10 @@ dl.timeline {
                     left: 100%;
                   }
                 }
+              }
+
+              .timeline-slot-date {
+                text-align: right;
               }
 
               &::after {
@@ -367,7 +370,6 @@ dl.timeline {
             @include desktop {
               padding-right: calc(#{$timeline-dt-left-padding} + #{$timeline-dt-right-padding});
               padding-left: calc(#{$gutter-width*.5});
-              text-align: right;
               grid-area: left;
 
               .timeline-slot-title {
@@ -391,6 +393,10 @@ dl.timeline {
                 }
               }
 
+              .timeline-slot-date {
+                text-align: right;
+              }
+
               &::after {
                 display: none;
               }
@@ -408,6 +414,24 @@ dl.timeline {
 
           &::after {
             bottom: calc(100% - $gutter-width*.5);
+          }
+
+          .timeline-slot-title {
+            &::after {
+              @include theme('border-color', 'color-tertiary-pastel', 'timeline-line-color');
+
+              position: absolute;
+              top: 0;
+              right: calc(100% + 24px);
+              bottom: 50%;
+              border-left: $timeline-border solid;
+              content: '';
+              z-index: 0;
+
+              @include desktop {
+                right: calc(100% + $timeline-dt-right-padding - $timeline-border/2);
+              }
+            }
           }
         }
 

--- a/components/41-organisms/timeline/timeline.twig
+++ b/components/41-organisms/timeline/timeline.twig
@@ -495,7 +495,7 @@
             <h4 class="timeline-slot-title">
               <button aria-expanded="false" aria-controls="timeline-slot-content--8"
                       data-controls-img="timeline-slot-img--8" class="accordion--button">
-                Timeline item title
+                Timeline item title with a lot of text so that it falls on the second line and creates a larger gap
               </button>
             </h4>
             <h5 class="timeline-slot-date">Timeline item subtitle/date</h5>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Items that are displayed left also have their text (but not titles) aligned left
- Line of the time line has correct height for the last item
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
