### PR TITLE
SGD8-2906: Fix multistep layout on mobile

### DIFF
--- a/components/31-molecules/form-steps/_form-steps.scss
+++ b/components/31-molecules/form-steps/_form-steps.scss
@@ -21,7 +21,7 @@
         margin-bottom: 0;
       }
 
-      &:not(:first-child):not(:last-child):not(.active) {
+      &:not(:first-child):not(:last-child):not(.active):not(.active + li) {
         @include desktop-and-below {
           // clip
           position: absolute;
@@ -77,7 +77,7 @@
         }
 
         &::before,
-        &::after {
+        & + li::after {
           @include desktop-and-below {
             @include theme('border-color', 'color-tertiary-pastel', 'form-step-hellip-background-color');
             @include theme('background-color', 'color-tertiary-pastel', 'form-step-hellip-background-color');
@@ -100,7 +100,7 @@
           @include theme('background-color', 'color-primary', 'form-step--active-background-color');
         }
 
-        &::after {
+        & + li:not(:nth-last-child(2)):not(:last-child)::after {
           @include desktop-and-below {
             content: '\2026';
           }
@@ -136,11 +136,10 @@
       &:nth-child(2)::before,
       &:nth-last-child(2)::after,
       &:last-child::after {
-        @include desktop-and-below {
+        @include desktop {
           content: none;
         }
       }
-
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Change mobile css for multistep forms so that the number after the active item is shown, unless it's the (second) last number
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
