### PR TITLE
SGD8-2548: added figcaption margins to cta block

### DIFF
--- a/components/31-molecules/cta-block/_cta-block.scss
+++ b/components/31-molecules/cta-block/_cta-block.scss
@@ -74,6 +74,10 @@
       }
     }
 
+    figcaption {
+      margin-right: 80px; // Overlap + 20px
+    }
+
     .cta-block__content {
       top: -20px;
       left: 20px;
@@ -105,6 +109,10 @@
       @include phablet {
         margin-left: inherit;
       }
+    }
+
+    figcaption {
+      margin-left: 80px; // Overlap + 20px
     }
 
     .cta-block__content {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- figcaption margins added for cta block
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
