### PR TITLE
SGD8-2604: Fix 1+2 item nr in steps

### DIFF
--- a/components/31-molecules/form-steps/_form-steps.scss
+++ b/components/31-molecules/form-steps/_form-steps.scss
@@ -132,8 +132,6 @@
         }
       }
 
-      &:first-child::before,
-      &:nth-child(2)::before,
       &:nth-last-child(2)::after,
       &:last-child::after {
         @include desktop {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Removed overwritten styling for first and second item in form-steps
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
