### PR TITLE
Revert "STIJ-444: Fix disabled submit button styling"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this style guide are documented here.
 
+## [6.0.3]
+
+### Fixed
+- Revert STIJ-444: Fix disabled button styling that was overwritten for submit buttons
+
 ## [6.0.2]
 
 ### Added
@@ -217,6 +222,7 @@ Add the `.contact-details--with-image` class to the contact-details section if y
 
 
 [6.x-dev unreleased]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.x...6.x-dev
+[6.0.3]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.2...6.0.3
 [6.0.2]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.1...6.0.2
 [6.0.1]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.0...6.0.1
 [6.0.0]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/5.1.7...6.0.0

--- a/components/21-atoms/button/button.twig
+++ b/components/21-atoms/button/button.twig
@@ -1,6 +1,6 @@
 <button
   type="button"
-  class="button {{ 'button-' ~ type }} {{ modifier }}{% if icon %} button-icon{% endif %}"
+  class="button {{ 'button-' ~ type }} {{ modifier }} {% if icon %}button-icon{% endif %}"
   {% if disabled %}
     disabled
   {% endif %}

--- a/components/21-atoms/input-submit/_input-submit.scss
+++ b/components/21-atoms/input-submit/_input-submit.scss
@@ -1,6 +1,6 @@
 input[type="submit"],
 button[type="submit"] {
-  &:not(.button-secondary):not(.button-success):not(.button-alert):enabled {
+  &:not(.button-secondary):not(.button-success):not(.button-alert) {
     @extend %button-primary;
   }
 }

--- a/components/21-atoms/input-submit/input-submit.twig
+++ b/components/21-atoms/input-submit/input-submit.twig
@@ -1,6 +1,6 @@
 <button
         type="submit"
-        class="button {{ 'button-' ~ type }}{% if modifier %} {{ modifier }}{% endif %}"
+        class="button {{ 'button-' ~ type }} {% if modifier %}{{ modifier }}{% endif %}"
 >
     {{ value }}
 </button>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 All notable changes to this style guide are documented here.
 
+## [6.0.3]
+
+### Fixed
+- Revert STIJ-444: Fix disabled button styling that was overwritten for submit buttons
+
 ## [6.0.2]
 
 ### Added
@@ -217,6 +222,7 @@ Add the `.contact-details--with-image` class to the contact-details section if y
 
 
 [6.x-dev unreleased]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.x...6.x-dev
+[6.0.3]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.2...6.0.3
 [6.0.2]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.1...6.0.2
 [6.0.1]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.0...6.0.1
 [6.0.0]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/5.1.7...6.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gent_styleguide",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gent_styleguide",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gent_styleguide",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Styleguide Stad.Gent",
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
Reverts StadGent/fractal_styleguide_gent-base#632 which introduced a button styling bug.

<img width="713" alt="Screenshot 2025-02-28 at 11 31 40" src="https://github.com/user-attachments/assets/2ab4f829-89cb-4aec-af78-a55ac2c976f7" />
