### PR TITLE
SGD8-2602: Remove unnecessary font extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this style guide are documented here.
 ### Changed
 - SGD8-2287: Changed tables' mobile theming to use swiper for 2nd column and onwards (`<table>` markup changes because of this).
 
+### Removed
+- SGD8-2602: Removed unnecessary font extensions (eot, ttf, woff and svg).
+
 ## [6.0.3]
 
 ### Fixed

--- a/components/11-base/fonts/_fonts.scss
+++ b/components/11-base/fonts/_fonts.scss
@@ -12,13 +12,8 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-regular.eot'),
-  local('Fira Sans'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-regular.eot?#iefix') format('embedded-opentype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-regular.woff2') format('woff2'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-regular.woff') format('woff'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-regular.ttf') format('truetype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-regular.svg#FiraSans') format('svg');
+  src: local('Fira Sans'),
+  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-regular.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -27,13 +22,8 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 600;
-  src: url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-600.eot'),
-  local('Fira Sans'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-600.eot?#iefix') format('embedded-opentype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-600.woff2') format('woff2'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-600.woff') format('woff'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-600.ttf') format('truetype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-600.svg#FiraSans') format('svg');
+  src: local('Fira Sans'),
+  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-600.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -42,13 +32,8 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 700;
-  src: url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-700.eot'),
-  local('Fira Sans'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-700.eot?#iefix') format('embedded-opentype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-700.woff2') format('woff2'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-700.woff') format('woff'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-700.ttf') format('truetype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-700.svg#FiraSans') format('svg');
+  src: local('Fira Sans'),
+  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-700.woff2') format('woff2');
   font-display: swap;
 }
 
@@ -57,13 +42,8 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 800;
-  src: url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-800.eot'),
-  local('Fira Sans'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-800.eot?#iefix') format('embedded-opentype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-800.woff2') format('woff2'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-800.woff') format('woff'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-800.ttf') format('truetype'),
-  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-800.svg#FiraSans') format('svg');
+  src: local('Fira Sans'),
+  url('#{$styleguide-dir}/googlefonts/fira-sans-v16-latin-ext_latin-800.woff2') format('woff2');
   font-display: swap;
 }
 

--- a/components/11-base/fonts/templates/_icons.template
+++ b/components/11-base/fonts/templates/_icons.template
@@ -11,12 +11,7 @@ $id: random(1000);
 
 @font-face {
   font-family: "<%= fontName %>";
-  src: url('#{$styleguide-dir}/fonts/<%= fontName %>.eot?v=#{$id}');
-  src: url('#{$styleguide-dir}/fonts/<%= fontName %>.eot?#iefix?v=#{$id}') format('eot'),
-  url('#{$styleguide-dir}/fonts/<%= fontName %>.woff2?v=#{$id}') format('woff2'),
-  url('#{$styleguide-dir}/fonts/<%= fontName %>.woff?v=#{$id}') format('woff'),
-  url('#{$styleguide-dir}/fonts/<%= fontName %>.ttf?v=#{$id}') format('truetype'),
-  url('#{$styleguide-dir}/fonts/<%= fontName %>.svg#<%= fontName %>?v=#{$id}') format('svg');
+  src: url('#{$styleguide-dir}/fonts/<%= fontName %>.woff2?v=#{$id}') format('woff2');
   font-display: swap;
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ All notable changes to this style guide are documented here.
 ### Changed
 - SGD8-2287: Changed tables' mobile theming to use swiper for 2nd column and onwards (`<table>` markup changes because of this).
 
+### Removed
+- SGD8-2602: Removed unnecessary font extensions (eot, ttf, woff and svg).
+
 ## [6.0.3]
 
 ### Fixed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove font extensions to only keep woff2
<!--- Describe your changes in detail -->

## Motivation and Context
- less calls and less files
- only IE11 and Opera Mini, which we don't support, don't support woff2
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
