### PR TITLE
SGD8-2982: Add cache param to font url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,7 +265,7 @@ Add the `.contact-details--with-image` class to the contact-details section if y
 
 
 [6.x-dev unreleased]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.x...6.x-dev
-[6.0.8]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.8...6.0.9
+[6.0.9]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.8...6.0.9
 [6.0.8]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.7...6.0.8
 [6.0.7]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.6...6.0.7
 [6.0.6]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.5...6.0.6

--- a/components/11-base/fonts/_fonts.scss
+++ b/components/11-base/fonts/_fonts.scss
@@ -13,7 +13,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('Fira Sans Regular'), local('FiraSans-Regular'),
-  url('#{$styleguide-dir}/googlefonts/FiraSans-Regular.woff2') format('woff2');
+  url('#{$styleguide-dir}/googlefonts/FiraSans-Regular.woff2?v2') format('woff2');
   font-display: swap;
 }
 
@@ -23,7 +23,7 @@
   font-style: normal;
   font-weight: 600;
   src: local('Fira Sans SemiBold'), local('FiraSans-SemiBold'),
-  url('#{$styleguide-dir}/googlefonts/FiraSans-SemiBold.woff2') format('woff2');
+  url('#{$styleguide-dir}/googlefonts/FiraSans-SemiBold.woff2?v2') format('woff2');
   font-display: swap;
 }
 
@@ -33,7 +33,7 @@
   font-style: normal;
   font-weight: 700;
   src: local('Fira Sans Bold'), local('FiraSans-Bold'),
-  url('#{$styleguide-dir}/googlefonts/FiraSans-Bold.woff2') format('woff2');
+  url('#{$styleguide-dir}/googlefonts/FiraSans-Bold.woff2?v2') format('woff2');
   font-display: swap;
 }
 
@@ -43,7 +43,7 @@
   font-style: normal;
   font-weight: 800;
   src: local('Fira Sans ExtraBold'), local('FiraSans-ExtraBold'),
-  url('#{$styleguide-dir}/googlefonts/FiraSans-ExtraBold.woff2') format('woff2');
+  url('#{$styleguide-dir}/googlefonts/FiraSans-ExtraBold.woff2?v2') format('woff2');
   font-display: swap;
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -265,7 +265,7 @@ Add the `.contact-details--with-image` class to the contact-details section if y
 
 
 [6.x-dev unreleased]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.x...6.x-dev
-[6.0.8]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.8...6.0.9
+[6.0.9]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.8...6.0.9
 [6.0.8]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.7...6.0.8
 [6.0.7]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.6...6.0.7
 [6.0.6]: https://github.com/StadGent/fractal_styleguide_gent-base/compare/6.0.5...6.0.6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add version parameter to font url for caching
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
