### PR TITLE
SGD8-2965: Change overlap content header with img overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this style guide are documented here.
 
 ## [Unreleased]
 
+## Changed
+- SGD8-2965: Changed overlap spacing for content headers with img overlap.
+
 ## Removed
 - SGD8-2982: Removed new fonts styling and reverted to old styling with eot and old font files.
 

--- a/components/61-layouts/detail-layout/_detail-layout.scss
+++ b/components/61-layouts/detail-layout/_detail-layout.scss
@@ -51,7 +51,7 @@
 
         @include desktop {
           max-width: calc($bp-max-content - 480px - 60px);
-          margin: -205px 0 100px;
+          margin: -225px 0 100px; // 225px = 165px (margin of content header with img overlap) + 60px.
         }
       }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,8 +4,11 @@ All notable changes to this style guide are documented here.
 
 ## [Unreleased]
 
+## Changed
+- SGD8-2965: Changed overlap spacing for content headers with img overlap.
+
 ## Removed
-- SGD8-2982: Removed new styling and reverted to old.
+- SGD8-2982: Removed new fonts styling and reverted to old styling with eot and old font files.
 
 ## [6.0.11]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Changed overlap spacing for content headers with img overlap to 60px
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the styleguide CHANGELOG accordingly.
