### PR TITLE
SGD8-2985: Remove opening-hours field in teaser mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this style guide are documented here.
 
 ## [6.0.16] Unreleased
 
+### Removed
+- SGD8-2985: Removed opening-hours field in teaser mobile.
+
 ### Updated
 - SGD8-2552: Updated accolade to new design.
 

--- a/components/31-molecules/teaser/_teaser.scss
+++ b/components/31-molecules/teaser/_teaser.scss
@@ -314,7 +314,8 @@
         }
       }
 
-      p {
+      p,
+      .opening-hours-accordion {
         display: none;
 
         @include tablet {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this style guide are documented here.
 
 ## [6.0.16] Unreleased
 
+### Removed
+- SGD8-2985: Removed opening-hours field in teaser mobile.
+
 ### Updated
 - SGD8-2552: Updated accolade to new design.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Removed opening-hours field from teaser on mobile view
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
