### PR TITLE
SGD8-2802: Remove margin from figcaption on full img

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this style guide are documented here.
 
 ### Removed
 - SGD8-2985: Removed opening-hours field in teaser mobile.
+- SGD8-2802: Removed margin from figcaption on full img.
 
 ### Updated
 - SGD8-2552: Updated accolade to new design.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this style guide are documented here.
 ## [6.0.17] Unreleased
 
 ### Updated
-- SGD8-2552: Updated accolade with 1px extra. 
+- SGD8-2552: Updated accolade with 1px extra.
+
+### Removed
+- SGD8-2802: Removed margin from figcaption on full img.
 
 ## [6.0.16]
 
 ### Removed
 - SGD8-2985: Removed opening-hours field in teaser mobile.
-- SGD8-2802: Removed margin from figcaption on full img.
 
 ### Updated
 - SGD8-2552: Updated accolade to new design.

--- a/components/21-atoms/figcaption/_figcaption.scss
+++ b/components/21-atoms/figcaption/_figcaption.scss
@@ -8,6 +8,8 @@ figcaption {
   line-height: 175%;
 
   .full-image & {
+    margin: 0;
+
     &::before {
       display: none;
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ All notable changes to this style guide are documented here.
 
 ### Removed
 - SGD8-2985: Removed opening-hours field in teaser mobile.
+- SGD8-2802: Removed margin from figcaption on full img.
 
 ### Updated
 - SGD8-2552: Updated accolade to new design.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,13 +5,15 @@ All notable changes to this style guide are documented here.
 ## [6.0.17] Unreleased
 
 ### Updated
-- SGD8-2552: Updated accolade with 1px extra. 
+- SGD8-2552: Updated accolade with 1px extra.
+
+### Removed
+- SGD8-2802: Removed margin from figcaption on full img.
 
 ## [6.0.16]
 
 ### Removed
 - SGD8-2985: Removed opening-hours field in teaser mobile.
-- SGD8-2802: Removed margin from figcaption on full img.
 
 ### Updated
 - SGD8-2552: Updated accolade to new design.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Set margins to 0 for figcaption on full-image (img gallery full size)
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the styleguide CHANGELOG accordingly.
