### PR TITLE
SGD8-2885: Fix partner block intro height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this style guide are documented here.
 
+## [Unreleased]
+
+## Fixed 
+
+- SGD8-2885: Fix partner block li height.
+
 ## [7.2.3]
 
 ### Fixed

--- a/components/31-molecules/partner-block/_partner-block.scss
+++ b/components/31-molecules/partner-block/_partner-block.scss
@@ -78,8 +78,15 @@
 
     li {
       width: auto;
-      height: 100px;
       margin: 0;
+    }
+  }
+
+  .partners {
+    ul {
+      li {
+        height: 100px;
+      }
     }
   }
 


### PR DESCRIPTION
Li in intor and li in partners now have different height 

<img width="1677" height="184" alt="Screenshot 2026-04-13 133304" src="https://github.com/user-attachments/assets/bd85d9fe-bfd1-4da8-9d16-400496fe34b9" />
<img width="1714" height="669" alt="Screenshot 2026-04-13 133327" src="https://github.com/user-attachments/assets/07035610-6bac-4082-a554-519cdff0ac69" />
